### PR TITLE
Fix: pypet exec now works with parameter snippets

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,7 +55,6 @@ def test_exec_with_id(runner, mock_storage):
         patch("rich.prompt.Confirm.ask", return_value=True),
         patch("subprocess.run") as mock_run,
     ):
-
         result = runner.invoke(main, ["exec", snippet_id])
         assert result.exit_code == 0
         mock_run.assert_called_once()
@@ -69,7 +68,6 @@ def test_exec_interactive_selection(runner, mock_storage):
         patch("rich.prompt.Confirm.ask", return_value=True),
         patch("subprocess.run") as mock_run,
     ):
-
         result = runner.invoke(main, ["exec"])
         assert result.exit_code == 0
         mock_run.assert_called_once()
@@ -86,7 +84,6 @@ def test_exec_with_edit(runner, mock_storage):
         patch("subprocess.run") as mock_run,
         patch("rich.prompt.Confirm.ask", return_value=True),
     ):
-
         result = runner.invoke(main, ["exec", snippet_id, "-e"])
         assert result.exit_code == 0
         mock_run.assert_called_once()
@@ -104,7 +101,6 @@ def test_exec_cancel(runner, mock_storage):
         patch("rich.prompt.Confirm.ask", return_value=False),
         patch("subprocess.run") as mock_run,
     ):
-
         result = runner.invoke(main, ["exec", snippet_id])
         assert result.exit_code == 0
         mock_run.assert_not_called()
@@ -116,7 +112,6 @@ def test_exec_interactive_invalid_choice(runner, mock_storage):
         patch("pypet.cli.storage", mock_storage),
         patch("rich.prompt.Prompt.ask", side_effect=["invalid", "q"]),
     ):
-
         result = runner.invoke(main, ["exec"])
         assert result.exit_code == 0
         assert "Please enter a number" in result.output
@@ -286,7 +281,6 @@ def test_exec_special_characters(runner, mock_storage):
         patch("rich.prompt.Confirm.ask", return_value=True),
         patch("subprocess.run") as mock_run,
     ):
-
         result = runner.invoke(main, ["exec", snippet_id])
         assert result.exit_code == 0
         mock_run.assert_called_once()
@@ -300,7 +294,6 @@ def test_exec_interactive_invalid_input(runner, mock_storage):
         patch("pypet.cli.storage", mock_storage),
         patch("rich.prompt.Prompt.ask", side_effect=["invalid", "q"]),
     ):
-
         result = runner.invoke(main, ["exec"])
         assert result.exit_code == 0
         assert "Please enter a number" in result.output
@@ -320,7 +313,6 @@ def test_copy_command(runner, mock_storage):
     snippet_id = snippets[0][0]
 
     with patch("pypet.cli.storage", mock_storage), patch("pyperclip.copy") as mock_copy:
-
         result = runner.invoke(main, ["copy", snippet_id])
         assert result.exit_code == 0
         mock_copy.assert_called_once_with("ls -la")
@@ -334,7 +326,6 @@ def test_copy_interactive_selection(runner, mock_storage):
         patch("rich.prompt.Prompt.ask", return_value="1"),
         patch("pyperclip.copy") as mock_copy,
     ):
-
         result = runner.invoke(main, ["copy"])
         assert result.exit_code == 0
         mock_copy.assert_called_once_with("ls -la")
@@ -355,7 +346,6 @@ def test_exec_with_copy_option(runner, mock_storage):
     snippet_id = snippets[0][0]
 
     with patch("pypet.cli.storage", mock_storage), patch("pyperclip.copy") as mock_copy:
-
         result = runner.invoke(main, ["exec", snippet_id, "--copy"])
         assert result.exit_code == 0
         mock_copy.assert_called_once_with("ls -la")
@@ -371,7 +361,6 @@ def test_copy_with_clipboard_error(runner, mock_storage):
         patch("pypet.cli.storage", mock_storage),
         patch("pyperclip.copy", side_effect=Exception("Clipboard error")),
     ):
-
         result = runner.invoke(main, ["copy", snippet_id])
         assert result.exit_code == 0
         assert "Failed to copy to clipboard" in result.output

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timezone
 import pytest
-from pypet.models import Snippet
+from pypet.models import Snippet, Parameter
 
 
 def test_snippet_creation():
@@ -126,3 +126,246 @@ def test_snippet_empty_tags():
 
     snippet = Snippet(command="test", tags=None)
     assert snippet.tags == []  # Should initialize to empty list
+
+
+# Parameter Tests
+
+
+def test_parameter_creation():
+    """Test basic parameter creation"""
+    param = Parameter(name="host")
+    assert param.name == "host"
+    assert param.default is None
+    assert param.description is None
+
+
+def test_parameter_with_default():
+    """Test parameter creation with default value"""
+    param = Parameter(name="port", default="8080")
+    assert param.name == "port"
+    assert param.default == "8080"
+    assert param.description is None
+
+
+def test_parameter_with_description():
+    """Test parameter creation with description"""
+    param = Parameter(name="user", description="Username for connection")
+    assert param.name == "user"
+    assert param.default is None
+    assert param.description == "Username for connection"
+
+
+def test_parameter_with_all_fields():
+    """Test parameter creation with all fields"""
+    param = Parameter(
+        name="timeout", default="30", description="Connection timeout in seconds"
+    )
+    assert param.name == "timeout"
+    assert param.default == "30"
+    assert param.description == "Connection timeout in seconds"
+
+
+def test_parameter_normalization():
+    """Test parameter field normalization"""
+    param = Parameter(name="  host  ", description="  Server host  ")
+    assert param.name == "host"
+    assert param.description == "Server host"
+
+
+def test_parameter_to_dict():
+    """Test parameter to dictionary conversion"""
+    param = Parameter(name="port", default="8080", description="Server port")
+    data = param.to_dict()
+    assert data == {"name": "port", "default": "8080", "description": "Server port"}
+
+
+def test_parameter_from_dict():
+    """Test parameter from dictionary creation"""
+    data = {"name": "host", "default": "localhost", "description": "Server hostname"}
+    param = Parameter.from_dict(data)
+    assert param.name == "host"
+    assert param.default == "localhost"
+    assert param.description == "Server hostname"
+
+
+# Snippet with Parameters Tests
+
+
+def test_snippet_with_formal_parameters():
+    """Test snippet creation with formal parameters"""
+    params = {
+        "host": Parameter("host", description="Server host"),
+        "port": Parameter("port", default="22", description="SSH port"),
+    }
+    snippet = Snippet(
+        command="ssh {user}@{host} -p {port}",
+        description="SSH connection",
+        parameters=params,
+    )
+
+    assert snippet.command == "ssh {user}@{host} -p {port}"
+    assert len(snippet.parameters) == 2
+    assert "host" in snippet.parameters
+    assert "port" in snippet.parameters
+
+
+def test_get_all_parameters_with_formal_only():
+    """Test get_all_parameters with only formally defined parameters"""
+    params = {
+        "host": Parameter("host", description="Server host"),
+        "port": Parameter("port", default="22"),
+    }
+    snippet = Snippet(command="ssh user@{host} -p {port}", parameters=params)
+
+    all_params = snippet.get_all_parameters()
+    assert len(all_params) == 2
+    assert "host" in all_params
+    assert "port" in all_params
+    assert all_params["host"].description == "Server host"
+    assert all_params["port"].default == "22"
+
+
+def test_get_all_parameters_discover_from_command():
+    """Test get_all_parameters discovering parameters from command string"""
+    snippet = Snippet(command="ssh {user}@{host} -p {port=22}")
+
+    all_params = snippet.get_all_parameters()
+    assert len(all_params) == 3
+    assert "user" in all_params
+    assert "host" in all_params
+    assert "port" in all_params
+
+    # Check discovered parameters
+    assert all_params["user"].default is None
+    assert all_params["host"].default is None
+    assert all_params["port"].default == "22"
+
+    # All discovered parameters should have no description
+    assert all_params["user"].description is None
+    assert all_params["host"].description is None
+    assert all_params["port"].description is None
+
+
+def test_get_all_parameters_mixed():
+    """Test get_all_parameters with both formal and discovered parameters"""
+    # Formal parameter definitions
+    formal_params = {
+        "host": Parameter("host", description="Server hostname"),
+        "timeout": Parameter("timeout", default="30", description="Connection timeout"),
+    }
+
+    # Command has both formal and additional parameters
+    snippet = Snippet(
+        command="ssh {user}@{host} -p {port=22} -o ConnectTimeout={timeout}",
+        parameters=formal_params,
+    )
+
+    all_params = snippet.get_all_parameters()
+    assert len(all_params) == 4  # host, timeout (formal) + user, port (discovered)
+
+    # Check formal parameters (should keep their definitions)
+    assert all_params["host"].description == "Server hostname"
+    assert all_params["timeout"].default == "30"
+    assert all_params["timeout"].description == "Connection timeout"
+
+    # Check discovered parameters
+    assert all_params["user"].default is None
+    assert all_params["user"].description is None
+    assert all_params["port"].default == "22"
+    assert all_params["port"].description is None
+
+
+def test_apply_parameters_no_params():
+    """Test apply_parameters on snippet without parameters"""
+    snippet = Snippet(command="docker ps")
+    result = snippet.apply_parameters({})
+    assert result == "docker ps"
+
+
+def test_apply_parameters_formal_params():
+    """Test apply_parameters with formally defined parameters"""
+    params = {
+        "host": Parameter("host", description="Server host"),
+        "port": Parameter("port", default="22"),
+    }
+    snippet = Snippet(command="ssh user@{host} -p {port}", parameters=params)
+
+    # With all parameters provided
+    result = snippet.apply_parameters({"host": "example.com", "port": "2222"})
+    assert result == "ssh user@example.com -p 2222"
+
+    # With only required parameter (should use default for port)
+    result = snippet.apply_parameters({"host": "example.com"})
+    assert result == "ssh user@example.com -p 22"
+
+
+def test_apply_parameters_discovered_params():
+    """Test apply_parameters with discovered parameters from command"""
+    snippet = Snippet(command="ssh {user}@{host} -p {port=22}")
+
+    # With all parameters provided
+    result = snippet.apply_parameters(
+        {"user": "admin", "host": "example.com", "port": "2222"}
+    )
+    assert result == "ssh admin@example.com -p 2222"
+
+    # With only required parameters (should use default for port)
+    result = snippet.apply_parameters({"user": "admin", "host": "example.com"})
+    assert result == "ssh admin@example.com -p 22"
+
+
+def test_apply_parameters_missing_required():
+    """Test apply_parameters with missing required parameters"""
+    snippet = Snippet(command="ssh {user}@{host} -p {port=22}")
+
+    # Missing required parameter should raise ValueError
+    with pytest.raises(
+        ValueError, match="No value provided for required parameter: host"
+    ):
+        snippet.apply_parameters({"user": "admin"})
+
+    with pytest.raises(
+        ValueError, match="No value provided for required parameter: user"
+    ):
+        snippet.apply_parameters({"host": "example.com"})
+
+
+def test_apply_parameters_complex_patterns():
+    """Test apply_parameters with various parameter patterns"""
+    snippet = Snippet(command="echo Hello {name} from {location=world} on port {port}")
+
+    result = snippet.apply_parameters(
+        {"name": "Alice", "location": "Mars", "port": "8080"}
+    )
+    assert result == "echo Hello Alice from Mars on port 8080"
+
+    # Test with default used
+    result = snippet.apply_parameters({"name": "Bob", "port": "9090"})
+    assert result == "echo Hello Bob from world on port 9090"
+
+
+def test_apply_parameters_dollar_syntax():
+    """Test apply_parameters with ${var} syntax"""
+    snippet = Snippet(command="echo ${message} to {user}")
+
+    result = snippet.apply_parameters({"message": "Hello", "user": "World"})
+    assert result == "echo Hello to World"
+
+
+def test_apply_parameters_edge_cases():
+    """Test apply_parameters with edge cases"""
+    # Empty braces should be ignored
+    snippet = Snippet(command="echo {} and {valid}")
+    result = snippet.apply_parameters({"valid": "test"})
+    assert result == "echo {} and test"
+
+    # Nested braces (should only process outer)
+    snippet = Snippet(command="echo {outer{inner}}")
+    # This should discover parameter "outer{inner"
+    all_params = snippet.get_all_parameters()
+    assert "outer{inner" in all_params
+
+    # Malformed parameters should be handled gracefully
+    snippet = Snippet(command="echo {missing_closing")
+    all_params = snippet.get_all_parameters()
+    assert len(all_params) == 0  # No valid parameters found


### PR DESCRIPTION
## Summary
This PR fixes issue #18 by implementing automatic parameter detection and handling for snippets that contain parameter placeholders but lack formal parameter definitions.

### Problem
`pypet exec` failed to work with parameter snippets like SSH commands (`ssh {user}@{host} -p {port=22}`) because:
- Parameters were not automatically detected from command strings
- Only formally defined parameters in TOML were processed
- CLI didn't prompt for undeclared parameters

### Solution
- ✅ **Automatic Parameter Discovery**: Added regex-based detection of `{name}` and `{name=default}` patterns
- ✅ **Enhanced Parameter Application**: Extended `apply_parameters()` to handle both formal and discovered parameters  
- ✅ **Smart CLI Prompting**: Only prompts for parameters not provided via command line
- ✅ **Improved Display**: Shows discovered parameters in `pypet list` and other commands
- ✅ **Backward Compatibility**: Maintains full compatibility with existing functionality

### Key Changes
1. **New `get_all_parameters()` method** - Discovers parameters from command strings
2. **Enhanced `apply_parameters()`** - Handles mixed formal/discovered parameters
3. **Updated CLI functions** - Better parameter prompting and display
4. **Comprehensive tests** - 18 new tests covering all parameter scenarios

### Example
**Before:**
```bash
$ pypet exec <ssh-snippet-id>
# Output: ssh {user}@{host} -p {port=22}  # ❌ No substitution
```

**After:**
```bash
$ pypet exec <ssh-snippet-id> -P user=admin -P host=example.com
# Output: ssh admin@example.com -p 22  # ✅ Works perfectly!

$ pypet list
# Now shows: user=<required>, host=<required>, port=22  # ✅ Parameters displayed
```

## Test plan
- [x] All existing tests pass (98/98)
- [x] New comprehensive parameter tests added (18 tests)
- [x] Manual testing with SSH snippet confirms fix works
- [x] Interactive parameter prompting tested
- [x] Parameter display in list/search commands verified
- [x] Code formatted with black and linted with ruff
- [x] Pre-push hooks pass

## Impact
- Fixes parameter snippets without breaking existing functionality
- Enhances user experience with automatic parameter detection
- Maintains 100% backward compatibility
- Improves parameter visibility in CLI commands

Closes #18

🤖 Generated with [Claude Code](https://claude.ai/code)