### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/fabiandistler/pypet/security/code-scanning/1](https://github.com/fabiandistler/pypet/security/code-scanning/1)

In general, the fix is to explicitly define `permissions` for the workflow or for each job so that the `GITHUB_TOKEN` has only the minimum required scopes. Since all three jobs here only need to read repository contents (checkout, install, test, lint, build, and upload coverage), we can safely set a workflow-wide permissions block with `contents: read`.

The single best fix with minimal functional impact is to add a root-level `permissions` block right after the `on:` section (or after `name:`) in `.github/workflows/ci.yml`. This block will apply to all jobs (`test`, `lint`, `build`) because they do not define their own permissions. No other changes are needed: no imports, no step modifications, and no additional permissions (like `pull-requests: write`) are required because the workflow does not modify repository state. Concretely, add:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
