### PR TITLE
docs: capture modernization ideas and draft MCP server proposal

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -1,0 +1,76 @@
+# pypet — Modernization Ideas
+
+Brainstorm zur Frage: Wie bleibt pypet relevant, wenn Entwickler:innen
+zunehmend mit KI-Agents statt direkt im Terminal arbeiten?
+
+Leitgedanke: pypet positioniert sich nicht als Konkurrenz zu KI-Agents,
+sondern als **persönliche und Team-Wissensschicht**, die Agents nutzen können.
+
+---
+
+## Idea 1 — pypet als MCP-Server für KI-Agents
+
+Status: **In Planung** (siehe `openspec/changes/2026-04-24-add-mcp-server/`)
+
+Stellt die pypet-Snippet-Bibliothek via Model Context Protocol für KI-Agents
+(Claude Code, Cursor, Copilot CLI etc.) zur Verfügung. Der Agent bekommt
+Tools wie `pypet_search`, `pypet_get`, `pypet_list_by_tag`.
+
+**Warum stark:** Der Agent kennt die persönlichen Vorlieben des Users —
+kubectl-Kombinationen, Docker-Cleanup-Patterns, projektspezifische
+Build-Befehle. pypet wird zum Langzeitgedächtnis über Agent-Sessions hinweg.
+
+**Bonus:** Die bestehende `gen`-Funktion könnte mittelfristig redundant
+werden (Agents generieren ohnehin), aber `save` und die Snippet-Bibliothek
+selbst werden dadurch zum Premium-Feature.
+
+---
+
+## Idea 2 — Auto-Capture aus Agent-Sessions ("Learn Mode")
+
+Status: **Idee**
+
+Gegenrichtung zu Idea 1: Wenn ein KI-Agent im Terminal einen komplexen
+Befehl erfolgreich ausführt (verzwickter `ffmpeg`- oder `awk`-One-Liner),
+bietet pypet an, ihn zu speichern — inklusive dem natürlichsprachlichen
+Kontext aus dem ursprünglichen Prompt.
+
+**Konkret:** Shell-Hook oder Agent-Plugin, das erkennt: "hier wurde gerade
+etwas Nicht-Triviales ausgeführt, exit code 0, lief ungewöhnlich
+lange/hatte viele Flags" → `pypet save-last --from-agent "der Prompt, der
+dazu führte"`. Beim nächsten Mal findest du es per Naturtext-Suche wieder,
+ohne den Agent dafür überhaupt zu bemühen.
+
+**Warum stark:** Löst das Problem, dass Agents oft dieselben Probleme
+immer wieder von Null lösen. Du baust dir passiv eine kuratierte
+Snippet-Bibliothek, ohne aktiv daran zu denken.
+
+---
+
+## Idea 3 — Projekt-/Team-Runbooks statt globaler Snippet-Liste
+
+Status: **Idee**
+
+Weg von "eine große Liste persönlicher Befehle", hin zu projektgebundenen,
+ausführbaren Runbooks. Eine `.pypet/` im Repo, die dem Team (und ihren
+Agents) sagt: "So deployed man hier, so testet man E2E, so rollt man
+zurück."
+
+**Konkret:** `pypet init` im Repo, Snippets werden mit Repo
+mitversioniert. Onboarding eines neuen Devs wird `pypet list` statt
+200-Seiten-Confluence-Dokument. Kombiniert mit Idea 1 bekommt der Agent
+eines neuen Devs sofort Zugriff aufs Team-Wissen.
+
+**Warum stark:** Das ist ein Problem, das Agents *nicht* lösen — sie
+halluzinieren gerne projektspezifische Details. Ein autoritatives,
+commit-bares Runbook-Format füllt diese Lücke.
+
+---
+
+## Reihenfolge
+
+1. **Idea 1** zuerst — kleinster Scope (Wrapper um bestehende Commands),
+   positioniert das Tool aber sofort neu im KI-Ökosystem.
+2. **Idea 3** als nächster strategischer Pivot (verändert das
+   Datenmodell: globale Snippets → projekt-gescopte Snippets).
+3. **Idea 2** als Komfort-Feature, sinnvoll erst wenn 1 + 3 stehen.

--- a/openspec/changes/2026-04-24-add-mcp-server/design.md
+++ b/openspec/changes/2026-04-24-add-mcp-server/design.md
@@ -1,0 +1,140 @@
+## Context
+
+pypet today is a human-facing CLI: a user types `pypet search git`,
+picks a snippet, and executes it. With AI coding agents taking over
+much of the direct terminal interaction, that interaction model is
+increasingly bypassed — agents regenerate commands from scratch each
+session instead of reusing the user's curated library.
+
+The Model Context Protocol (MCP) is the emerging standard for exposing
+local tools and data sources to AI agents. Claude Desktop, Claude Code,
+Cursor, and a growing set of clients consume MCP servers over stdio.
+By shipping pypet as an MCP server, we make the user's snippet library
+a first-class capability for their agent.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Expose pypet snippets to any MCP-compatible client with a single
+  command: `pypet mcp`.
+- Reuse the existing `Storage` API without duplication.
+- Keep the core `pypet-cli` install footprint unchanged (the `mcp`
+  dependency is opt-in via `pip install pypet-cli[mcp]`).
+- Provide safe, read-heavy tools plus a write tool (`create_snippet`)
+  so the agent can persist newly-discovered commands.
+- Resolve parameter placeholders server-side so the agent receives
+  ready-to-run command strings.
+
+**Non-Goals:**
+
+- Executing snippets from the MCP server. The agent decides whether
+  and how to run the resolved command using its own shell tool,
+  preserving the user's approval flow.
+- Supporting MCP transports beyond stdio in v1.
+- Adding authentication or ACLs. The server is a local, per-user
+  process with the same file-system authority as the CLI.
+- Exposing sync, alias, or AI-generation commands via MCP in v1. They
+  are out of scope for the memory-layer use case and can be added
+  later if justified.
+
+## Decisions
+
+**1. Use the official `mcp` Python SDK as an optional extra.**
+
+- We add a new optional dependency group `mcp = ["mcp>=1.0"]` in
+  `pyproject.toml`. Users install it with `pip install pypet-cli[mcp]`.
+- The `pypet mcp` command imports the SDK lazily inside the command
+  handler and raises a friendly error with install instructions if the
+  extra is missing.
+- **Rationale:** The MCP protocol is non-trivial to implement correctly
+  (stdio framing, JSON-RPC, capability negotiation). The SDK is
+  maintained by Anthropic and used by every reference server. Making
+  it optional keeps the zero-cost install that pypet's audience expects
+  for a simple snippet manager.
+
+**2. stdio transport only in v1.**
+
+- The server runs under `pypet mcp` using the SDK's `stdio_server()`
+  context manager.
+- **Rationale:** Every target client (Claude Desktop, Claude Code,
+  Cursor) supports stdio. HTTP/SSE adds deployment complexity (ports,
+  auth) and is unnecessary for a per-user local tool. We can add it
+  later without breaking changes.
+
+**3. Five tools, read-heavy, with a deliberate omission of `execute`.**
+
+Exposed tools:
+
+- `search_snippets(query: str, tag: str | None)` — wraps
+  `Storage.search_snippets`. Returns `[{id, command, description, tags,
+  parameters}]`.
+- `list_snippets(tag: str | None)` — wraps `Storage.list_snippets`,
+  with in-memory tag filtering.
+- `get_snippet(snippet_id: str)` — wraps `Storage.get_snippet`,
+  including the full parameter schema (name, default, description).
+- `resolve_snippet(snippet_id: str, parameters: dict[str, str])` —
+  reuses the existing parameter-substitution logic from
+  `pypet/parameters.py` and returns `{command: str}`. Does **not**
+  execute.
+- `create_snippet(command, description, tags?, parameters?)` — wraps
+  `Storage.add_snippet`, returns the new snippet ID.
+
+Deliberately omitted:
+
+- `execute_snippet`: letting the agent run shell commands directly
+  removes the user's review step. The agent already has a shell tool
+  in every target client; we hand it a resolved string and let its
+  existing approval flow apply.
+- `delete_snippet`, `update_snippet`: destructive and easy to misuse.
+  Users can invoke them through the CLI when needed.
+
+**4. Return snippet IDs verbatim.**
+
+- Tool responses include the same short IDs the CLI uses, so agents can
+  cross-reference what the user sees in `pypet list`.
+- **Rationale:** Consistency between the human and agent views is the
+  whole point of the feature.
+
+**5. Error surface: raise, let the SDK convert.**
+
+- Tool handlers raise plain exceptions (e.g. `ValueError` for unknown
+  IDs). The MCP SDK converts them to structured JSON-RPC errors.
+- **Rationale:** No custom error type needed. Matches how the CLI
+  commands currently surface errors.
+
+**6. No new storage code.**
+
+- `mcp_server.py` is a thin adapter: it instantiates `Storage()` and
+  translates MCP tool calls to storage method calls. If we need
+  behavior beyond what `Storage` exposes, we add it to `Storage`, not
+  to the MCP adapter.
+- **Rationale:** Avoids a second, drifting representation of snippet
+  operations.
+
+## Risks / Trade-offs
+
+- **Risk:** Agent writes low-quality or duplicate snippets via
+  `create_snippet`.
+  - **Mitigation:** The tool description instructs agents to check for
+    existing similar snippets first (via `search_snippets`). Users can
+    always review via `pypet list` and delete. For v1 we accept the
+    trade-off — if duplicates become a real problem, we can add a
+    dedup heuristic to `Storage.add_snippet`.
+- **Risk:** Installing the `mcp` extra pulls in transitive dependencies
+  that bloat the CLI.
+  - **Mitigation:** It is opt-in. Users who only want the CLI pay
+    nothing. CI covers both install modes.
+- **Risk:** The MCP SDK's API changes before 1.0 is stable.
+  - **Mitigation:** Pin `mcp>=1.0`. If the SDK breaks, only users with
+    the optional extra are affected, and the core CLI keeps working.
+- **Trade-off:** Not exposing `execute_snippet` means the agent has to
+  call `resolve_snippet` and then its shell tool — a two-step dance.
+  We accept this friction in exchange for keeping the execution
+  decision in the user-visible shell-tool approval flow.
+- **Risk:** Confusion between `pypet gen` (generates a snippet via
+  OpenRouter) and the MCP server (lets an agent generate snippets
+  directly).
+  - **Mitigation:** README section explaining which to use when. In the
+    mid-term, `pypet gen` can become a convenience wrapper — the MCP
+    route is the strategic direction.

--- a/openspec/changes/2026-04-24-add-mcp-server/proposal.md
+++ b/openspec/changes/2026-04-24-add-mcp-server/proposal.md
@@ -1,0 +1,68 @@
+## Why
+
+Developers increasingly drive their terminal work through AI coding agents
+(Claude Code, Cursor, Copilot CLI). In that workflow, a human-facing
+snippet manager is bypassed: the agent generates commands from scratch
+each time and has no memory of the user's personal conventions, flags,
+or project-specific workflows.
+
+Exposing pypet's snippet library via the Model Context Protocol (MCP)
+repositions the tool as a **long-term memory layer for AI agents**. The
+agent gains tools to search, read, and create pypet snippets, and can
+use the user's curated commands instead of re-deriving them. This
+complements, rather than competes with, AI agents.
+
+## What Changes
+
+- Add a new `pypet mcp` subcommand that starts an MCP server on stdio.
+- Add a thin server module `pypet/mcp_server.py` built on the official
+  `mcp` Python SDK, exposing pypet's `Storage` through MCP tools.
+- Expose the following MCP tools (v1):
+  - `search_snippets(query, tag?)` — full-text search, optionally filtered by tag.
+  - `list_snippets(tag?)` — enumerate snippets (optionally filtered by tag).
+  - `get_snippet(snippet_id)` — fetch one snippet including parameter schema.
+  - `resolve_snippet(snippet_id, parameters)` — substitute parameter
+    placeholders and return the final command string **without executing it**.
+  - `create_snippet(command, description, tags?, parameters?)` —
+    persist a new snippet to the user's library.
+- Treat `mcp` as an **optional extra** (`pip install pypet-cli[mcp]`) so
+  the core CLI keeps its fast, small-footprint install.
+- Document the integration for Claude Code and Claude Desktop in the README.
+
+## Capabilities
+
+### New Capabilities
+
+- `mcp-server`: Exposes pypet snippets to AI agents via the Model Context
+  Protocol, turning the local snippet library into shared memory across
+  agent sessions.
+
+### Modified Capabilities
+
+None. The MCP server is a new frontend over the existing `Storage` API
+and does not alter snippet semantics or on-disk format.
+
+## Impact
+
+- New module `pypet/mcp_server.py`.
+- New CLI command file `pypet/cli/mcp_commands.py` (Click integration).
+- New optional dependency group `[project.optional-dependencies].mcp =
+  ["mcp>=1.0"]` in `pyproject.toml`.
+- New test file `tests/test_mcp_server.py`.
+- README section with example client configuration.
+- No changes to `Storage`, `models.py`, or the TOML snippet format.
+- No impact on users who do not install the `mcp` extra.
+
+## Non-Goals
+
+- **No snippet execution via MCP.** An `execute_snippet` tool is deliberately
+  omitted from v1. Agents should call `resolve_snippet` and then run the
+  resolved command through their own shell tool, keeping the user in the loop.
+- **No HTTP/SSE transport in v1.** stdio is sufficient for every current
+  MCP client (Claude Desktop, Claude Code, Cursor). Remote transport can
+  be added later if needed.
+- **No authentication layer.** The server runs locally under the user's
+  shell account and only accesses the user's own snippet file.
+- **No agent-facing telemetry.** We do not track which snippets agents
+  use; that is out of scope and would conflict with the project's
+  privacy-first stance.

--- a/openspec/changes/2026-04-24-add-mcp-server/specs/mcp-server/spec.md
+++ b/openspec/changes/2026-04-24-add-mcp-server/specs/mcp-server/spec.md
@@ -1,0 +1,95 @@
+## ADDED Requirements
+
+### Requirement: Start MCP Server
+
+The system SHALL provide a `pypet mcp` command that starts a Model
+Context Protocol server on stdio, exposing the user's snippet library
+to MCP-compatible AI agents.
+
+#### Scenario: MCP extra installed
+
+- **WHEN** the user runs `pypet mcp` with the `mcp` optional extra
+  installed
+- **THEN** the system starts an MCP server on stdio and blocks,
+  listening for JSON-RPC messages until the client disconnects
+
+#### Scenario: MCP extra not installed
+
+- **WHEN** the user runs `pypet mcp` without the `mcp` optional extra
+  installed
+- **THEN** the system prints a message instructing the user to run
+  `pip install pypet-cli[mcp]` and exits with a non-zero status code
+
+### Requirement: Expose Snippet Read Tools
+
+The server SHALL expose tools that let agents discover and read the
+user's snippets without modifying them.
+
+#### Scenario: Searching snippets
+
+- **WHEN** an agent calls the `search_snippets` tool with a query
+  string and an optional tag filter
+- **THEN** the server returns the list of matching snippets, each with
+  `id`, `command`, `description`, `tags`, and `parameters`
+
+#### Scenario: Listing snippets by tag
+
+- **WHEN** an agent calls the `list_snippets` tool with a `tag`
+  argument
+- **THEN** the server returns only snippets whose tag list contains
+  that tag
+
+#### Scenario: Fetching a single snippet
+
+- **WHEN** an agent calls the `get_snippet` tool with a known snippet
+  ID
+- **THEN** the server returns the full snippet record including its
+  parameter schema
+
+#### Scenario: Fetching an unknown snippet
+
+- **WHEN** an agent calls the `get_snippet` tool with an unknown ID
+- **THEN** the server raises an error that the MCP SDK surfaces as a
+  structured JSON-RPC error to the client
+
+### Requirement: Resolve Parameters Without Execution
+
+The server SHALL resolve parameter placeholders into a final command
+string without executing the command.
+
+#### Scenario: Resolving a parameterized snippet
+
+- **WHEN** an agent calls `resolve_snippet` with a snippet ID and a
+  mapping of parameter names to values
+- **THEN** the server returns a `{command}` object containing the
+  substituted command string and does not execute it
+
+#### Scenario: Missing required parameter
+
+- **WHEN** an agent calls `resolve_snippet` without providing a value
+  for a parameter that has no default
+- **THEN** the server raises an error indicating which parameter is
+  missing
+
+### Requirement: Create Snippets From the Agent
+
+The server SHALL allow agents to persist new snippets on behalf of the
+user.
+
+#### Scenario: Creating a snippet
+
+- **WHEN** an agent calls `create_snippet` with a command,
+  description, optional tags, and optional parameter schema
+- **THEN** the server persists the snippet using the same storage
+  layer as the CLI and returns the new snippet's ID
+
+### Requirement: No Remote Execution
+
+The server SHALL NOT expose a tool that executes snippets on the host.
+
+#### Scenario: Attempting execution via MCP
+
+- **WHEN** an agent inspects the tool catalog
+- **THEN** no tool named `execute_snippet` (or equivalent) is
+  advertised, and the agent must invoke its own shell tool on the
+  output of `resolve_snippet` to run a command

--- a/openspec/changes/2026-04-24-add-mcp-server/tasks.md
+++ b/openspec/changes/2026-04-24-add-mcp-server/tasks.md
@@ -1,0 +1,64 @@
+## 1. Dependencies and Packaging
+
+- [ ] 1.1 Add optional dependency group `mcp = ["mcp>=1.0"]` to
+  `pyproject.toml` under `[project.optional-dependencies]`.
+- [ ] 1.2 Confirm `uv pip install -e ".[mcp]"` installs cleanly and
+  `uv pip install -e "."` does not pull the MCP SDK.
+- [ ] 1.3 Add a short note to `AGENTS.md` about the new optional
+  install target.
+
+## 2. Server Implementation
+
+- [ ] 2.1 Create `pypet/mcp_server.py` with a `run()` entry point that
+  constructs an MCP `Server`, registers tool handlers, and starts
+  `stdio_server()`.
+- [ ] 2.2 Implement tool `search_snippets(query, tag?)` backed by
+  `Storage.search_snippets`, applying tag filter in-memory if provided.
+- [ ] 2.3 Implement tool `list_snippets(tag?)` backed by
+  `Storage.list_snippets`.
+- [ ] 2.4 Implement tool `get_snippet(snippet_id)` backed by
+  `Storage.get_snippet`; raise `ValueError` on unknown ID.
+- [ ] 2.5 Implement tool `resolve_snippet(snippet_id, parameters)` that
+  reuses the parameter substitution logic from `pypet/parameters.py`
+  and returns `{command: <resolved string>}` without executing.
+- [ ] 2.6 Implement tool `create_snippet(command, description, tags?,
+  parameters?)` backed by `Storage.add_snippet`; return the new ID.
+- [ ] 2.7 Define JSON schemas for each tool's input using the MCP SDK's
+  schema helpers so clients see typed parameters.
+- [ ] 2.8 Ensure snippet responses include `{id, command, description,
+  tags, parameters}` in a stable shape shared across tools.
+
+## 3. CLI Integration
+
+- [ ] 3.1 Create `pypet/cli/mcp_commands.py` with a Click command `mcp`.
+- [ ] 3.2 Lazy-import `pypet.mcp_server` inside the command; on
+  `ImportError` print a friendly message instructing the user to
+  `pip install pypet-cli[mcp]` and exit with code 1.
+- [ ] 3.3 Wire the new command into `pypet/cli/__init__.py` or
+  `pypet/cli/main.py` next to the existing subcommand registrations.
+- [ ] 3.4 Verify `pypet mcp --help` renders and `pypet --help` lists
+  the new command.
+
+## 4. Testing
+
+- [ ] 4.1 Add `tests/test_mcp_server.py` covering each tool handler
+  directly (bypassing the stdio layer) against a temporary
+  `Storage` instance with fixture snippets.
+- [ ] 4.2 Cover failure paths: unknown snippet ID, missing required
+  parameter on `resolve_snippet`, empty search result.
+- [ ] 4.3 Add a CLI test that `pypet mcp` prints the install hint when
+  the `mcp` package is not importable (monkeypatch the import).
+- [ ] 4.4 Run `make all` and ensure ruff, mypy, and pytest all pass in
+  both install modes (with and without `[mcp]`).
+
+## 5. Documentation
+
+- [ ] 5.1 Add a "Use pypet with AI agents (MCP)" section to `README.md`
+  with:
+  - Install command: `pip install pypet-cli[mcp]`.
+  - Example Claude Desktop `claude_desktop_config.json` snippet.
+  - Example Claude Code / Cursor MCP config snippet.
+  - A 2-line summary of the available tools.
+- [ ] 5.2 Add an entry to `CHANGELOG.md` under an unreleased section.
+- [ ] 5.3 Update `AGENTS.md` with a one-paragraph description of the
+  new capability and the tool surface.


### PR DESCRIPTION
Add IDEAS.md with three strategic directions for keeping pypet
relevant in an AI-agent-driven workflow (MCP server, auto-capture
from agent sessions, project-scoped runbooks).

Draft an openspec change for Idea 1 (MCP server) so the plan is
visible, reviewable, and ready to implement: proposal, design
decisions, tasks, and capability spec delta.